### PR TITLE
Don't delete files in the staged repository when synchronizing

### DIFF
--- a/src/main/scala/GhPages.scala
+++ b/src/main/scala/GhPages.scala
@@ -38,8 +38,6 @@ object GhPages extends Plugin {
     private def synchLocal0 = (privateMappings, updatedRepository, GitKeys.gitRunner, streams) map { (mappings, repo, git, s) =>
       // TODO - an sbt.Synch with cache of previous mappings to make this more efficient. */
       val betterMappings = mappings map { case (file, target) => (file, repo / target) }
-      // First, remove 'stale' files.
-      cleanSiteForRealz(repo, git, s)
       // Now copy files.
       IO.copy(betterMappings)
       repo


### PR DESCRIPTION
The documentation says that the push task must not remove the existing files in the staged repository (because the clean site task allows to do that), then I think that this line should be removed from the synchLocal task.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sbt/sbt-ghpages/3)
<!-- Reviewable:end -->
