### PR TITLE
Be able to set custom commit messages.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtGhPages.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtGhPages.scala
@@ -62,7 +62,9 @@ object SbtGhPages extends Plugin {
         git(("rm" :: "-r" :: "-f" :: "--ignore-unmatch" :: toClean) :_*)(dir, s.log)
       ()
     }
-    private def pushSite0 = (synchLocal, GitKeys.gitRunner, streams) map { (repo, git, s) => git.commitAndPush("updated site")(repo, s.log) }
+
+    val commitMessage = sys.env.getOrElse("SBT_GHPAGES_COMMIT_MESSAGE", "updated site")
+    private def pushSite0 = (synchLocal, GitKeys.gitRunner, streams) map { (repo, git, s) => git.commitAndPush(commitMessage)(repo, s.log) }
 
 
     /** TODO - Create ghpages in the first place if it doesn't exist.


### PR DESCRIPTION
This should (hopefully) let users customize the commit message that sbt-ghpages uses.

This lets people optionally include things like flags to turn off testing automation or commit announcements for these commits, by doing something like:

```
$ SBT_GHPAGES_COMMIT_MESSAGE='Latest API docs. [ci skip]' sbt ghpages-push-site
```
