### PR TITLE
Upgrade sbt-git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a `project/plugins.sbt` file that looks like the following:
 
     resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 
 
 Then in your build.sbt file, simply add:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-ghpages"
 
 organization := "com.typesafe.sbt"
 
-version := "0.5.3"
+version := "0.5.4-SNAPSHOT"
 
 publishMavenStyle := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.5
+sbt.version = 0.13.8

--- a/project/build.scala
+++ b/project/build.scala
@@ -5,7 +5,7 @@ object ghpages extends Build {
   lazy val root = Project("sbt-ghpages", file(".")) settings(
      resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
      resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven",
-     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4"),
+     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.4"),
      addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
   )
 }


### PR DESCRIPTION
I started to convert this to an AutoPlugin but then decided not to use it at all. In any event, the upgrade of sbt-git to version 0.8.4 does no harm and reduces eviction notices in other projects that use later versions of sbt-git.  Thought you might like the update since I had the change made.