### PR TITLE
Migrate to AutoPlugin. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,30 @@ the web with GitHub Pages where it will be served at
 
 ## Adding the plugin to your project ##
 
+*Note, sbt-ghpages now requires the use of sbt version 0.13.5 or greater.*
+
 Create a `project/plugins.sbt` file that looks like the following:
 
 ```scala
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
 ```
 
-Then in your `build.sbt` file, simply add:
+Then in your `build.sbt` file, simply enable the GhPagesPlugin via an
+`enablePlugins` statement for your project, and specify the location of
+your github repository (for more information on enabling and disabling sbt plugins,
+see the [sbt plugin documentation](http://www.scala-sbt.org/0.13/docs/Using-Plugins.html#Enabling+and+disabling+auto+plugins)):
 
 ```scala
-ghpages.settings
+enablePlugins(GhPagesPlugin)
 
 git.remoteRepo := "git@github.com:{your username}/{your project}.git"
 ```
+### Settings
+
+sbt-ghpages provides the following optional setting keys for use in your `build.sbt` file:
+
+- `GhPages.repository` - Location of the sandbox repository to be used to check out the gh-pages branch.
+- `GhPages.noJekyll` - If set to true will cause a .nojekyll file to be generated, to prevent GitHub from running Jekyll on pushed sites.
 
 
 ## Initializing the gh-pages branch ##
@@ -72,9 +81,10 @@ Simply run the `ghpagesPushSite` task to publish your website.
 ### How it works
 
 Behind the scenes, `sbt-ghpages` will create a new "sandbox" clone of your Git
-repository, stashed away beneath `~/.sbt/ghpages`. Whenever you run `sbt
-ghpagesPushSite` it will copy your site content into that sandbox repository,
-commit it to the `gh-pages` branch, and push the branch to GitHub.
+repository, with its location determined by the `GhPages.repository` setting key
+(by default set to a directory under `~/.sbt/ghpages`). Whenever you run `sbt ghpagesPushSite`
+it will copy your site content into that sandbox repository, commit it to the
+`gh-pages` branch, and push the branch to GitHub.
 
 The sandbox repo approach spares you from doing the `gh-pages` checkout/commit
 dance yourself each time you update your site content, while avoiding any
@@ -84,11 +94,12 @@ mistakes with dirty or untracked files in your normal working copy clone.
 ## Publishing Scaladoc
 
 A common use for `sbt-ghpages` is to automate the publishing of Scaladoc. If you wish to
-use it for this, first ask `sbt-site` to generate your Scaladoc by adding this
-setting to your `build.sbt`:
+use it for this, first ask `sbt-site` to generate your Scaladoc by adding an `enablePlugins` directive
+for the `SiteScaladocPlugin` (included in sbt-site) to your `build.sbt` see the
+[sbt-site documentation](https://github.com/sbt/sbt-site#scaladoc-apis) for more information:
 
 ```scala
-site.includeScaladoc()
+enablePlugins(SiteScaladocPlugin)
 ```
 
 After using `ghpagesPushSite` you should find your Scaladoc at:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.11

--- a/project/build.scala
+++ b/project/build.scala
@@ -6,6 +6,6 @@ object ghpages extends Build {
      resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns),
      resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven",
      addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5"),
-     addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
+     addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
   )
 }

--- a/src/main/scala/com/typesafe/sbt/GhPagesPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/GhPagesPlugin.scala
@@ -5,13 +5,20 @@ import Keys._
 import com.typesafe.sbt.SbtGit.GitKeys
 import com.typesafe.sbt.git.GitRunner
 import GitKeys.{gitBranch, gitRemoteRepo}
-import com.typesafe.sbt.SbtSite.SiteKeys.siteMappings
+import com.typesafe.sbt.site.SitePlugin
 
-// Plugin to make use of githup pages.
-object SbtGhPages extends Plugin {
+// Plugin to make use of github pages.
+object GhPagesPlugin extends AutoPlugin {
+
+  override val trigger: PluginTrigger = noTrigger
+
+  override val  requires: Plugins = SitePlugin && GhPagesPlugin
+
+  override lazy val  projectSettings: Seq[Setting[_]] = ghPagesProjectSettings
+
   object GhPagesKeys {
     lazy val repository = SettingKey[File]("ghpages-repository", "sandbox environment where git project ghpages branch is checked out.")
-    lazy val ghpagesNoJekyll = SettingKey[Boolean]("ghpages-no-jekyll", "If this flag is set, ghpages will automatically generate a .nojekyll file to prevent github from running jekyll on pushed sites.")
+    lazy val noJekyll = SettingKey[Boolean]("ghpages-no-jekyll", "If this flag is set, ghpages will automatically generate a .nojekyll file to prevent github from running jekyll on pushed sites.")
     lazy val updatedRepository = TaskKey[File]("ghpages-updated-repository", "Updates the local ghpages branch on the sandbox repository.")
     // Note:  These are *only* here in the event someone wants to completely bypass the sbt-site plugin.
     lazy val privateMappings = mappings in synchLocal
@@ -20,14 +27,17 @@ object SbtGhPages extends Plugin {
     lazy val pushSite = TaskKey[Unit]("ghpages-push-site", "Pushes a generated site into the ghpages branch.  Will not clean the branch unless you run clean-site first.")
   }
 
+
+  object autoImport {
+    val GhPages = GhPagesKeys // make it easy for users to use  ghpages keys in .sbt files with GhPages.<key> syntax
+  }
+
   // TODO - Add some sort of locking to the repository so only one thread accesses it at a time...
-  object ghpages {
     import GhPagesKeys._
 
-    // TODO - Should we wire into default settings?
-    lazy val settings: Seq[Setting[_]] = Seq(
+    def ghPagesProjectSettings: Seq[Setting[_]] = Seq(
       //example: gitRemoteRepo := "git@github.com:jsuereth/scala-arm.git",
-      ghpagesNoJekyll := true,
+      noJekyll := true,
       repository := {
         val buildHash: String =
           Hash.toHex(Hash.apply(sbt.Keys.thisProjectRef.value.build.toASCIIString))
@@ -36,7 +46,7 @@ object SbtGhPages extends Plugin {
       gitBranch in updatedRepository <<= gitBranch ?? Some("gh-pages"),
       updatedRepository <<= updatedRepo(repository, gitRemoteRepo, gitBranch in updatedRepository),
       pushSite <<= pushSite0,
-      privateMappings <<= siteMappings,
+      privateMappings <<= mappings in SitePlugin.autoImport.makeSite,
       synchLocal <<= synchLocal0,
       cleanSite <<= cleanSite0
     )
@@ -46,7 +56,7 @@ object SbtGhPages extends Plugin {
          local
     }
 
-    private def synchLocal0 = (privateMappings, updatedRepository, ghpagesNoJekyll, GitKeys.gitRunner, streams) map { (mappings, repo, noJekyll, git, s) =>
+    private def synchLocal0 = (privateMappings, updatedRepository, noJekyll, GitKeys.gitRunner, streams) map { (mappings, repo, noJekyll, git, s) =>
       // TODO - an sbt.Synch with cache of previous mappings to make this more efficient. */
       val betterMappings = mappings map { case (file, target) => (file, repo / target) }
       // First, remove 'stale' files.
@@ -72,15 +82,14 @@ object SbtGhPages extends Plugin {
 
 
     /** TODO - Create ghpages in the first place if it doesn't exist.
-        $ cd /path/to/fancypants
-        $ git symbolic-ref HEAD refs/heads/gh-pages
-        $ rm .git/index
-        $ git clean -fdx
-        <copy api and documentation>
-        $ echo "My GitHub Page" > index.html
-        $ git add .
-        $ git commit -a -m "First pages commit"
-        $ git push origin gh-pages
+        *$ cd /path/to/fancypants
+        *$ git symbolic-ref HEAD refs/heads/gh-pages
+        *$ rm .git/index
+        *$ git clean -fdx
+        *<copy api and documentation>
+        *$ echo "My GitHub Page" > index.html
+        *$ git add .
+        *$ git commit -a -m "First pages commit"
+        *$ git push origin gh-pages
      */
-  }
 }

--- a/src/main/scala/com/typesafe/sbt/GhPagesPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/GhPagesPlugin.scala
@@ -12,7 +12,7 @@ object GhPagesPlugin extends AutoPlugin {
 
   override val trigger: PluginTrigger = noTrigger
 
-  override val  requires: Plugins = SitePlugin && GhPagesPlugin
+  override val  requires: Plugins = SitePlugin && GitPlugin
 
   override lazy val  projectSettings: Seq[Setting[_]] = ghPagesProjectSettings
 


### PR DESCRIPTION
Since both sbt-site and sbt-git are now `AutoPlugin`s, it makes sense to go the same route and have inclusion of settings (and dependent settings) managed via the `enablePlugins` mechanism.

This changes `SbtGhPages` to `GhPagesPlugin` to match with the changes undergone in other plugins already during their migration to AutoPlugin (eg SbtSite => SitePlugin, SbtGit => GitPlugin etc.).

Users can use the plugin and include settings by simply adding an `enablePlugins(SbtGhPages)` statement to their build.sbt file.
