### PR TITLE
bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,5 +6,5 @@ lazy val root = (project in file("."))
     version := "0.6.0-SNAPSHOT",
     resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven",
     addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5"),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,6 @@ lazy val root = (project in file("."))
     organization := "com.typesafe.sbt",
     version := "0.6.0-SNAPSHOT",
     resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven",
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5"),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3"),
+    addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.1")
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.16


### PR DESCRIPTION
In preparation for sbt 1.0.x.

Includes #33.

Missing plugins to move forward to 1.0.x:
* [ ] sbt-site
* [ ] sbt-git (seems to be ready, but not released yet)