### PR TITLE
Use `git add -f` in sandbox repo

### DIFF
--- a/src/main/scala/com/typesafe/sbt/sbtghpages/GhpagesPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/sbtghpages/GhpagesPlugin.scala
@@ -88,7 +88,7 @@ object GhpagesPlugin extends AutoPlugin {
       val git = GitKeys.gitRunner.value
       val repo = ghpagesSynchLocal.value
       val s = streams.value.log
-      git("add", ".")(repo, s)
+      git("add", "-f", ".")(repo, s)
       try {
         val commit = "commit" +: ghpagesCommitOptions.value
         git(commit: _*)(repo, s)


### PR DESCRIPTION
Since the contents of this repo are autogenerated (and supposed to match
exactly the SBT site produced), it makes no sense to respect any
`.gitignore` settings when committing for GH pages.